### PR TITLE
fix(popularity): fix db request for popularity of a single ship

### DIFF
--- a/src/main/kotlin/com/github/sylux6/watanabot/modules/azur_lane/commands/AzurLanePopularityCommand.kt
+++ b/src/main/kotlin/com/github/sylux6/watanabot/modules/azur_lane/commands/AzurLanePopularityCommand.kt
@@ -51,6 +51,7 @@ object AzurLanePopularityCommand : AbstractCommand("popularity") {
                 AzurLaneUsers
                     .slice(AzurLaneUsers.userId, AzurLaneUsers.oathId, AzurLaneUsers.oathDate)
                     .select { AzurLaneUsers.oathId.isNotNull() }
+                    .filter { event.guild.getMemberById(it[AzurLaneUsers.userId]) != null }
                     .groupBy { it[AzurLaneUsers.oathId]!! }
                     .mapValues { (_, value) ->
                         value


### PR DESCRIPTION
Filter members who are no longer in the server on using the popularity command for a single ship

closes #113 